### PR TITLE
修复已失效的示例

### DIFF
--- a/src/main/java/com/github/xjtushilei/example/PriorityQueueSpider.java
+++ b/src/main/java/com/github/xjtushilei/example/PriorityQueueSpider.java
@@ -23,7 +23,7 @@ public class PriorityQueueSpider {
                 .setSaver(mySaver)
                 .setProcessor(myPageProcessor)
                 .thread(10)
-                .addUrlSeed("http://news.xjtu.edu.cn/")
+                .addUrlSeed("http://news.xjtu.edu.cn/rcpy.htm")
                 .addRegexRule("+http://news.xjtu.edu.cn/.*") //限制爬取《交大新闻网》以外的其他站点的信息
                 .run();
     }

--- a/src/main/java/com/github/xjtushilei/example/PriorityQueueSpider.java
+++ b/src/main/java/com/github/xjtushilei/example/PriorityQueueSpider.java
@@ -23,7 +23,7 @@ public class PriorityQueueSpider {
                 .setSaver(mySaver)
                 .setProcessor(myPageProcessor)
                 .thread(10)
-                .addUrlSeed("http://news.xjtu.edu.cn/zsjy.htm")
+                .addUrlSeed("http://news.xjtu.edu.cn/")
                 .addRegexRule("+http://news.xjtu.edu.cn/.*") //限制爬取《交大新闻网》以外的其他站点的信息
                 .run();
     }
@@ -60,7 +60,7 @@ public class PriorityQueueSpider {
             Document htmldoc = page.getDocument();
             //select返回的是一个数组，所以需要first，相关语法请google“jsoup select语法”和“cssquery”
             try {
-                String title = htmldoc.select(".d_title").first().text();
+                String title = htmldoc.select(".ssd").first().text();
 
                 //用来存放爬取到的信息，供之后存储！map类型的即可，可以自定义各种嵌套！
                 Map<String, String> items = new HashMap<String, String>();
@@ -76,23 +76,23 @@ public class PriorityQueueSpider {
         /**
          * 这里进行了优先级的用法示范。
          *
-         * 比如，你想在“交大新闻网”尽快或者优先爬取“招生就业”类型的新闻。
-         * 然后我们发现，这一类新闻的url符合 “http://newsxq.xjtu.edu.cn/info/1006/.*”
+         * 比如，你想在“交大新闻网”尽快或者优先爬取“人才培养”类型的新闻。
+         * 然后我们发现，这一类新闻的url符合 “http://news.xjtu.edu.cn/info/1003/.*”
          *
          */
         @Override
         public void processNewUrlSeeds(Page page) {
 
-            //招生就业模块，符合 “http://newsxq.xjtu.edu.cn/info/1006/.*htm” 或者“http://news.xjtu.edu.cn/zsjy/.*htm”（翻页时候的url），进行设置高优先级设置
+            //人才培养模块，符合 “http://news.xjtu.edu.cn/info/1006/.*htm” 或者“http://news.xjtu.edu.cn/rcpy/.*htm”（翻页时候的url），进行设置高优先级设置
             page.getNewUrlSeed().forEach(urlSeed -> {
-                if (Pattern.matches("http://news.xjtu.edu.cn/zsjy.*htm", urlSeed.getUrl()) || Pattern.matches("http://news.xjtu.edu.cn/info/1006/.*htm", urlSeed.getUrl())) {
+                if (Pattern.matches("http://news.xjtu.edu.cn/rcpy.*htm", urlSeed.getUrl()) || Pattern.matches("http://news.xjtu.edu.cn/info/1003/.*htm", urlSeed.getUrl())) {
                     urlSeed.setPriority(8);
                 }
             });
 
-            //综合新闻 板块 ，符合“http://newsxq.xjtu.edu.cn/info/1002/.*htm” 或者"http://news.xjtu.edu.cn/zhxw.htm"(翻页时候的url），进行设置低优先级设置
+            //要闻聚焦 板块 ，符合“http://news.xjtu.edu.cn/info/1002/.*htm” 或者"http://news.xjtu.edu.cn/ywjj.htm"(翻页时候的url），进行设置低优先级设置
             page.getNewUrlSeed().forEach(urlSeed -> {
-                if (Pattern.matches("http://news.xjtu.edu.cn/zhxw.*htm", urlSeed.getUrl()) || Pattern.matches("http://news.xjtu.edu.cn/info/1002/.*htm", urlSeed.getUrl())) {
+                if (Pattern.matches("http://news.xjtu.edu.cn/ywjj.*htm", urlSeed.getUrl()) || Pattern.matches("http://news.xjtu.edu.cn/info/1002/.*htm", urlSeed.getUrl())) {
                     urlSeed.setPriority(2);
                 }
             });

--- a/src/main/java/com/github/xjtushilei/example/RedisSpider.java
+++ b/src/main/java/com/github/xjtushilei/example/RedisSpider.java
@@ -60,7 +60,7 @@ public class RedisSpider {
             Document htmldoc = page.getDocument();
             //select返回的是一个数组，所以需要first，相关语法请google“jsoup select语法”和“cssquery”
             try {
-                String title = htmldoc.select(".d_title").first().text();
+                String title = htmldoc.select(".ssd").first().text();
 
                 //用来存放爬取到的信息，供之后存储！map类型的即可，可以自定义各种嵌套！
                 Map<String, String> items = new HashMap<String, String>();

--- a/src/main/java/com/github/xjtushilei/example/SimpleSpider.java
+++ b/src/main/java/com/github/xjtushilei/example/SimpleSpider.java
@@ -51,8 +51,8 @@ public class SimpleSpider {
             Document htmldoc = page.getDocument();
             //select返回的是一个数组，所以需要first，相关语法请google“jsoup select语法”和“cssquery”
             try {
-                String title = htmldoc.select(".d_title").first().text();
-                String text = htmldoc.select(".d_detail").first().text();
+                String title = htmldoc.select(".ssd").first().text();
+                String text = htmldoc.select(".v_news_content").first().text();
 
                 //用来存放爬取到的信息，供之后存储！map类型的即可，可以自定义各种嵌套！
                 Map<String, String> items = new HashMap<String, String>();

--- a/src/main/java/com/github/xjtushilei/example/百科名医/百科名医爬虫入口.java
+++ b/src/main/java/com/github/xjtushilei/example/百科名医/百科名医爬虫入口.java
@@ -15,9 +15,9 @@ public class 百科名医爬虫入口 {
                 .setProcessor(new 页面解析器())
                 .setSaver(new 结果保存器())
                 .addUrlSeed("http://www.baikemy.com/disease/list/0/0")
-                .addRegexRule("http://www.baikemy.com/disease/list/\\d*/\\d*") //添加科室list页面
+                .addRegexRule("http://www.baikemy.com/disease/list/\\d*/\\d*\\?diseaseContentType=A") //添加科室list页面
                 .addRegexRule("http://www.baikemy.com/disease/view/\\d*") //添加疾病概述页面
-                .addRegexRule("http://www.baikemy.com/disease/detail/\\d*/1") //添加疾病具体内容页面
+                .addRegexRule("http://www.baikemy.com/disease/detail/\\d*") //添加疾病具体内容页面
                 .run();
     }
 }

--- a/src/main/java/com/github/xjtushilei/example/百科名医/页面解析器.java
+++ b/src/main/java/com/github/xjtushilei/example/百科名医/页面解析器.java
@@ -18,13 +18,13 @@ public class 页面解析器 implements PageProcessor {
     public void process(Page page) {
 //http://www.baikemy.com/disease/list/1/34
         //如果匹配到具体的页面，则可以解析出我们关注的这个疾病的具体信息。
-        if (Pattern.matches("http://www.baikemy.com/disease/detail/\\d*/1", page.getUrlSeed().getUrl())) {
+        if (Pattern.matches("http://www.baikemy.com/disease/detail/\\d*", page.getUrlSeed().getUrl())) {
 
             //解析想要的东西
             Document d = page.getDocument();
-            String type = d.selectFirst("div.jb-mb > a:nth-child(5)").text();
-            String name = d.selectFirst(" div.jb-head-left-text").text();
-            String content = d.select(".lemma-main").text();
+            String type = d.selectFirst("div.nav_wrap > a:nth-child(2)").text();
+            String name = d.selectFirst("div.detail_name").text();
+            String content = d.select(".content#specialityVersion").get(0).text();
 
             //用来存放爬取到的信息，供之后存储！map类型的即可，可以自定义各种嵌套！
             Map<String, String> items = new HashMap<String, String>();


### PR DESCRIPTION
主要是修改页面解析器，原有的解析方式已失效。

具体地：

1. http://news.xjtu.edu.cn/zsjy.htm 页面已不存在，替换为 http://news.xjtu.edu.cn/rcpy.htm
2. 页面内部元素名变更，解析式已替换为正确的名字，如解析标题时原类名为"d_title"，现在为"ssd"，正文及其他同理
3. 百科名医的正则过滤存在问题，简单改正了正则式
